### PR TITLE
Disable yarn scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,8 +8,6 @@ compressionLevel: mixed
 
 defaultSemverRangePrefix: ""
 
-enableScripts: true
-
 nodeLinker: pnp
 
 patchFolder: ./.yarn/patches


### PR DESCRIPTION
@
### Description
Remove `enableScripts: true` from `.yarnrc.yml`. Yarn defaults to enabling scripts, so making it explicit serves no purpose — and dropping it leaves the door open to flip it off in future without ceremony.

### Related issue
N/A

### Check list
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
@