### PR TITLE
Exclude vite from license checks

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -8,3 +8,18 @@ allow_licenses:
   - 'MIT'
   - 'CC0-1.0'
   - 'Unlicense'
+
+allow_dependencies_licenses:
+  # lightningcss (pulled in by vite) is MPL-2.0, but it's a dev-only dependency that is never shipped in distributed output
+  - 'pkg:npm/lightningcss'
+  - 'pkg:npm/lightningcss-android-arm64'
+  - 'pkg:npm/lightningcss-darwin-arm64'
+  - 'pkg:npm/lightningcss-darwin-x64'
+  - 'pkg:npm/lightningcss-freebsd-x64'
+  - 'pkg:npm/lightningcss-linux-arm-gnueabihf'
+  - 'pkg:npm/lightningcss-linux-arm64-gnu'
+  - 'pkg:npm/lightningcss-linux-arm64-musl'
+  - 'pkg:npm/lightningcss-linux-x64-gnu'
+  - 'pkg:npm/lightningcss-linux-x64-musl'
+  - 'pkg:npm/lightningcss-win32-arm64-msvc'
+  - 'pkg:npm/lightningcss-win32-x64-msvc'

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -14,3 +14,16 @@ allowed:
 
 reviewed:
   npm:
+    # lightningcss (pulled in by vite) is MPL-2.0, but it's a dev-only dependency that is never shipped in distributed output
+    - lightningcss
+    - lightningcss-android-arm64
+    - lightningcss-darwin-arm64
+    - lightningcss-darwin-x64
+    - lightningcss-freebsd-x64
+    - lightningcss-linux-arm-gnueabihf
+    - lightningcss-linux-arm64-gnu
+    - lightningcss-linux-arm64-musl
+    - lightningcss-linux-x64-gnu
+    - lightningcss-linux-x64-musl
+    - lightningcss-win32-arm64-msvc
+    - lightningcss-win32-x64-msvc


### PR DESCRIPTION
### Description
Exclude vite from license checks — it's MPL-2.0 but dev-only and never shipped in distributed output. Mirrors the exclusion in flyway-actions.

### Related issue
N/A

### Check list
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.